### PR TITLE
fix: Snapshot container CSS

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,15 +1,19 @@
+:root {
+  --bottomSpacing: 140px;
+}
+
 .ClaymateApp .excalidraw .App-menu_bottom {
-  bottom: 120px;
+  bottom: var(--bottomSpacing);
 }
 
 .ClaymateApp .excalidraw .layer-ui__wrapper__footer {
-  bottom: 120px;
+  bottom: var(--bottomSpacing);
 }
 
 .ClaymateApp .excalidraw .App-bottom-bar {
-  bottom: 120px;
+  bottom: var(--bottomSpacing);
 }
 
 .ClaymateApp .excalidraw .App-menu__left {
-  max-height: calc(100vh - 120px - 200px);
+  max-height: calc(100vh - var(--bottomSpacing) - 200px);
 }

--- a/src/Claymate.css
+++ b/src/Claymate.css
@@ -5,8 +5,7 @@
   left: 0;
   margin: 4px;
   padding: 4px;
-  height: calc(120px - 4 * 4px);
-  overflow: scroll;
+  height: calc(var(--bottomSpacing) - 4 * 4px);
   display: grid;
   grid-gap: 4px;
   grid-template-columns: auto 1fr;
@@ -57,17 +56,27 @@
 
 .Claymate-snapshots {
   display: flex;
-  overflow: scroll;
+  overflow-y: hidden;
+  overflow-x: scroll;
 }
 
 .Claymate-snapshot {
-  height: calc(120px - 4 * 4px);
+  height: 100%;
   border-left: lightgray solid 1px;
   position: relative;
+  width: 128px;
+  min-width: 128px;
 }
 
 .Claymate-snapshot canvas {
-  height: 100%;
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
 }
 
 .Claymate-snapshot:hover .Claymate-delete,


### PR DESCRIPTION
This PR changes the CSS related to the snapshot container with the goals:
- centralize the bottom spacing value into a single point: variable `--bottomSpacing`;
- fix the unnecessary horizontal and vertical scroll bars;
- fit the snapshot inside the preview area;

## Attachments

### Before

<details>

<summary>Scrolls were being displayed by default</summary>

![image](https://user-images.githubusercontent.com/11169832/111085527-8437c200-84f6-11eb-97b3-b248d24bbc2f.png)

</details>

<details>

<summary>Large width and height images were changing the preview aspect ratio, which results in bad UX</summary>


https://user-images.githubusercontent.com/11169832/111085640-f5777500-84f6-11eb-914f-b077baa89984.mp4

</details>

### After

<details>

<summary>Verticall scrolls are disabled</summary>

![image](https://user-images.githubusercontent.com/11169832/111085902-450a7080-84f8-11eb-8569-55cf7198eed6.png)

</details>

<details>

<summary>The preview has a fixed width and height and the snapshot fits inside it</summary>

https://user-images.githubusercontent.com/11169832/111085934-71be8800-84f8-11eb-9fe8-69a6f8d2459c.mp4

</details>