### PR TITLE
fix: revert hardcoded style values

### DIFF
--- a/src/Claymate.css
+++ b/src/Claymate.css
@@ -9,10 +9,10 @@
   grid-gap: 4px;
   grid-template-columns: 1fr auto;
 
-  background-color: var(--bg-color-island);
+  background-color: rgba(255, 255, 255, 0.9);
   backdrop-filter: saturate(100%) blur(10px);
-  box-shadow: var(--shadow-island);
-  border-radius: var(--border-radius-m);
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
   padding: 8px;
   transition: box-shadow 0.5s ease-in-out;
 }


### PR DESCRIPTION
The preview from #10 and my local dev env was displaying the style correctly though it is wrong in production:

![image](https://user-images.githubusercontent.com/11169832/111318968-4c3e9500-8644-11eb-9973-501ae76e42b6.png)
