### PR TITLE
feat: animateOrder config

### DIFF
--- a/src/AnimateConfig.css
+++ b/src/AnimateConfig.css
@@ -1,0 +1,7 @@
+.AnimateConfig {
+  height: 100%;
+  border-radius: 4px;
+  box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15);
+  padding: 2px;
+  font-size: small;
+}

--- a/src/AnimateConfig.tsx
+++ b/src/AnimateConfig.tsx
@@ -1,0 +1,109 @@
+import React, { ChangeEvent, Dispatch, SetStateAction } from "react";
+
+import "./AnimateConfig.css";
+import { Drawing, Scene } from "./types";
+
+const extractNumberFromId = (id: string, key: string) => {
+  const match = id.match(new RegExp(`${key}:(-?\\d+)`));
+  return match === null ? undefined : Number(match[1]) || 0;
+};
+
+const applyNumberInId = (
+  drawing: Drawing,
+  ids: string[],
+  key: string,
+  value: number
+): Drawing => {
+  const selectedElementIds = { ...drawing.appState.selectedElementIds };
+  const elements = drawing.elements.map((element) => {
+    const { id } = element;
+    if (!ids.includes(id)) {
+      return element;
+    }
+    let newId: string;
+    const match = id.match(new RegExp(`${key}:(-?\\d+)`));
+    if (match) {
+      newId = id.replace(new RegExp(`${key}:(-?\\d+)`), `${key}:${value}`);
+    } else {
+      newId = id + `-${key}:${value}`;
+    }
+    if (id === newId) {
+      return element;
+    }
+    selectedElementIds[newId] = selectedElementIds[id];
+    delete selectedElementIds[id];
+    return { ...element, id: newId };
+  });
+  return {
+    elements,
+    appState: {
+      ...drawing.appState,
+      selectedElementIds,
+    },
+  };
+};
+
+type Props = {
+  animateEnabled: boolean;
+  setAnimateEnabled: Dispatch<SetStateAction<boolean>>;
+  scene: Scene | undefined;
+  updateDrawing: (drawing: Drawing) => void;
+};
+
+const AnimateConfig: React.FC<Props> = ({
+  animateEnabled,
+  setAnimateEnabled,
+  scene,
+  updateDrawing,
+}) => {
+  const elements = scene?.drawing.elements ?? [];
+  const selectedIds = Object.keys(
+    scene?.drawing.appState.selectedElementIds ?? {}
+  ).filter((id) => elements.some((element) => element.id === id));
+  const animateOrderSet = new Set<number | undefined>();
+  selectedIds.forEach((id) => {
+    animateOrderSet.add(extractNumberFromId(id, "animateOrder"));
+  });
+  const onChangeAnimateOrder = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = Math.floor(Number(e.target.value));
+    if (scene && Number.isFinite(value)) {
+      updateDrawing(
+        applyNumberInId(scene.drawing, selectedIds, "animateOrder", value)
+      );
+    }
+  };
+  return (
+    <div className="AnimateConfig">
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={animateEnabled}
+            onChange={() => setAnimateEnabled((x) => !x)}
+          />
+          Enable animate
+        </label>
+      </div>
+      <div style={{ opacity: animateOrderSet.size ? 1.0 : 0.3 }}>
+        Animate order:{" "}
+        {animateOrderSet.size > 1 ? (
+          <>(mixed)</>
+        ) : (
+          <input
+            disabled={!animateOrderSet.size}
+            value={
+              (animateOrderSet.size === 1 &&
+                animateOrderSet.values().next().value) ||
+              0
+            }
+            onChange={onChangeAnimateOrder}
+            type="number"
+            style={{ width: 30 }}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AnimateConfig;

--- a/src/AnimateConfig.tsx
+++ b/src/AnimateConfig.tsx
@@ -72,6 +72,7 @@ const AnimateConfig: React.FC<Props> = ({
       );
     }
   };
+  const animateOrderDisabled = !animateEnabled || !animateOrderSet.size;
   return (
     <div className="AnimateConfig">
       <div>
@@ -84,13 +85,13 @@ const AnimateConfig: React.FC<Props> = ({
           Enable animate
         </label>
       </div>
-      <div style={{ opacity: animateOrderSet.size ? 1.0 : 0.3 }}>
+      <div style={{ opacity: animateOrderDisabled ? 0.3 : 1.0 }}>
         Animate order:{" "}
         {animateOrderSet.size > 1 ? (
           <>(mixed)</>
         ) : (
           <input
-            disabled={!animateOrderSet.size}
+            disabled={animateOrderDisabled}
             value={
               (animateOrderSet.size === 1 &&
                 animateOrderSet.values().next().value) ||

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { useRef } from "react";
 import Excalidraw from "@excalidraw/excalidraw";
+import type { ExcalidrawAPIRefValue } from "@excalidraw/excalidraw/types/types";
+import type { ExcalidrawImperativeAPI } from "@excalidraw/excalidraw/types/components/App";
 import "./App.css";
 import Claymate from "./Claymate";
+import { Drawing } from "./types";
 import { useScenes } from "./useScenes";
 
 const App: React.FC = () => {
+  const excalidrawRef = useRef<ExcalidrawAPIRefValue>(null);
+  const updateDrawing = (drawing: Drawing) => {
+    (excalidrawRef.current as ExcalidrawImperativeAPI | null)?.updateScene(
+      drawing
+    );
+  };
   const {
     moveToScene,
     addScene,
@@ -19,6 +28,7 @@ const App: React.FC = () => {
   return (
     <div className="ClaymateApp">
       <Excalidraw
+        ref={excalidrawRef}
         key={drawingVersion}
         initialData={initialData}
         onChange={onChange}
@@ -29,6 +39,7 @@ const App: React.FC = () => {
         updateScenes={updateScenes}
         moveToScene={moveToScene}
         addScene={addScene}
+        updateDrawing={updateDrawing}
       />
     </div>
   );

--- a/src/Claymate.css
+++ b/src/Claymate.css
@@ -7,7 +7,7 @@
   height: calc(var(--bottomSpacing) - 4 * 4px);
   display: grid;
   grid-gap: 4px;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: 1fr auto auto;
   background-color: rgba(255, 255, 255, 0.9);
   backdrop-filter: saturate(100%) blur(10px);
   box-shadow: 0 1px 5px rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
[excalidraw-animate](https://github.com/dai-shi/excalidraw-animate) has a secret feature of "animateOrder" embedded in element  id. This PR adds an UI to configure it.

<img width="405" alt="image" src="https://user-images.githubusercontent.com/490574/121794578-62a8bc80-cc44-11eb-9484-9d5d93f5c85c.png">
