### PR TITLE
Protect creation.ts

### DIFF
--- a/src/creation.ts
+++ b/src/creation.ts
@@ -9,6 +9,9 @@ export const createScene = (
   const canvas = exportToCanvas({ elements: drawing.elements });
   const width = size ? size.width : canvas.width;
   const height = size ? size.height : canvas.height;
+  if (!width || !height) {
+    return;
+  }
   const ctx = canvas.getContext("2d");
   if (ctx) {
     return {


### PR DESCRIPTION
Protect createScene from passing a faulty width or height to the getImageData call when exportToCanvas returns a zero width or height. Closes #38 