### PR TITLE
feat: recording video in exported html

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The main difference is in the footer, where you can:
   - an animated GIF
   - an HTML slide show
     - with animation (configurable order & speed)
-    - with video recording
+    - with video recording (See [#46](https://github.com/dai-shi/excalidraw-claymate/pull/46) for instructions)
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ The main difference is in the footer, where you can:
 - reorder scenes
 - export the scenes as either:
   - an animated GIF
-  - an HTML slide show (w/ animation, configurable order & speed).
+  - an HTML slide show
+    - with animation (configurable order & speed)
+    - with video recording
 
 Notes:
 


### PR DESCRIPTION
If you export to html and then open the html file in Chrome, you can record video of your slides (with or without animations).

## Steps without audio

1. Click record button
2. Select Chrome Tab in screen sharing
3. Deny microphone access
4. (after finished) Stop screen sharing

## Steps with audio

1. Click record button
2. Select Chrome Tab in screen sharing
3. Allow microphone access
4. (after finished) Stop screen sharing
5. Click the record button again to save file

---


https://user-images.githubusercontent.com/490574/130374726-46553208-3834-46a1-969c-07e53d0ec228.mov

