### PR TITLE
feat: add clear all and multi-select scene deletion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ const App = () => {
   const {
     moveToScene,
     addScene,
+    clearScenes,
     onChange,
     drawingVersion,
     currentIndex,
@@ -47,6 +48,7 @@ const App = () => {
         updateScenes={updateScenes}
         moveToScene={moveToScene}
         addScene={addScene}
+        clearScenes={clearScenes}
       />
     </div>
   );

--- a/src/Claymate.css
+++ b/src/Claymate.css
@@ -90,6 +90,11 @@
   border: 1px dotted gray;
 }
 
+.Claymate-scene:has(.Claymate-select:checked) {
+  background-color: rgba(99, 179, 237, 0.25);
+  border-color: #63b3ed;
+}
+
 .Claymate-scene canvas {
   display: block;
   max-width: 100%;
@@ -105,6 +110,17 @@
 .Claymate-scene:hover .Claymate-left,
 .Claymate-scene:hover .Claymate-right {
   display: block;
+}
+
+.Claymate-select {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  cursor: pointer;
+  z-index: 1;
 }
 
 .Claymate-delete {

--- a/src/Claymate.css
+++ b/src/Claymate.css
@@ -106,7 +106,6 @@
   margin: 0;
 }
 
-.Claymate-scene:hover .Claymate-delete,
 .Claymate-scene:hover .Claymate-left,
 .Claymate-scene:hover .Claymate-right {
   display: block;
@@ -121,16 +120,6 @@
   margin: 0;
   cursor: pointer;
   z-index: 1;
-}
-
-.Claymate-delete {
-  display: none;
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  width: 24px;
-  height: 24px;
-  padding: 0;
 }
 
 .Claymate-left {

--- a/src/Claymate.test.tsx
+++ b/src/Claymate.test.tsx
@@ -1,0 +1,185 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render, fireEvent } from '@testing-library/react';
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import Claymate from './Claymate';
+import type { Scene } from './types';
+
+const makeScene = (id: string, elements: any[] = []): Scene => ({
+  id,
+  width: 100,
+  height: 100,
+  imageData: {} as ImageData,
+  drawing: {
+    elements,
+    appState: { theme: 'light' } as any,
+    files: null,
+  },
+});
+
+const renderClaymate = (override: Record<string, unknown> = {}) => {
+  const props = {
+    scenes: [makeScene('a'), makeScene('b'), makeScene('c')],
+    currentIndex: 0 as number | undefined,
+    updateScenes: vi.fn(),
+    moveToScene: vi.fn(),
+    addScene: vi.fn(),
+    clearScenes: vi.fn(),
+    ...override,
+  };
+  const utils = render(<Claymate {...(props as any)} />);
+  return { props, ...utils };
+};
+
+let excalidrawHost: HTMLElement;
+
+beforeEach(() => {
+  excalidrawHost = document.createElement('div');
+  excalidrawHost.className = 'excalidraw';
+  excalidrawHost.innerHTML = '<input class="excalidraw-input" />';
+  document.body.appendChild(excalidrawHost);
+});
+
+afterEach(() => {
+  excalidrawHost.remove();
+});
+
+const selectScene = (
+  utils: ReturnType<typeof renderClaymate>,
+  index: number,
+) => {
+  const checkboxes = utils.getAllByLabelText('Select scene');
+  fireEvent.click(checkboxes[index]);
+};
+
+test('clicking a scene checkbox does not navigate to that scene', () => {
+  const utils = renderClaymate();
+  selectScene(utils, 1);
+  expect(utils.props.moveToScene).not.toHaveBeenCalled();
+});
+
+test('Delete removes only the selected scenes', () => {
+  const utils = renderClaymate();
+  selectScene(utils, 1);
+
+  fireEvent.keyDown(document.body, { key: 'Delete' });
+
+  expect(utils.props.updateScenes).toHaveBeenCalledTimes(1);
+  expect(utils.props.clearScenes).not.toHaveBeenCalled();
+  const updater = (utils.props.updateScenes as any).mock.calls[0][0];
+  const result = updater(utils.props.scenes).map((s: Scene) => s.id);
+  expect(result).toEqual(['a', 'c']);
+});
+
+test('Backspace removes only the selected scenes', () => {
+  const utils = renderClaymate();
+  selectScene(utils, 0);
+  selectScene(utils, 2);
+
+  fireEvent.keyDown(document.body, { key: 'Backspace' });
+
+  expect(utils.props.updateScenes).toHaveBeenCalledTimes(1);
+  const updater = (utils.props.updateScenes as any).mock.calls[0][0];
+  const result = updater(utils.props.scenes).map((s: Scene) => s.id);
+  expect(result).toEqual(['b']);
+});
+
+test('selecting all scenes and pressing Delete clears to one empty scene', () => {
+  const utils = renderClaymate();
+  selectScene(utils, 0);
+  selectScene(utils, 1);
+  selectScene(utils, 2);
+
+  fireEvent.keyDown(document.body, { key: 'Delete' });
+
+  expect(utils.props.clearScenes).toHaveBeenCalledTimes(1);
+  expect(utils.props.updateScenes).not.toHaveBeenCalled();
+});
+
+test('Delete does nothing when no scene is selected', () => {
+  const utils = renderClaymate();
+
+  fireEvent.keyDown(document.body, { key: 'Delete' });
+
+  expect(utils.props.updateScenes).not.toHaveBeenCalled();
+  expect(utils.props.clearScenes).not.toHaveBeenCalled();
+});
+
+test('Delete is ignored when focus is inside the Excalidraw canvas', () => {
+  const utils = renderClaymate();
+  selectScene(utils, 1);
+
+  const target = excalidrawHost.querySelector('input')!;
+  fireEvent.keyDown(target, { key: 'Delete' });
+
+  expect(utils.props.updateScenes).not.toHaveBeenCalled();
+  expect(utils.props.clearScenes).not.toHaveBeenCalled();
+});
+
+test('Delete is ignored when focus is in an input field', () => {
+  const utils = renderClaymate();
+  selectScene(utils, 1);
+
+  const input = document.createElement('input');
+  document.body.appendChild(input);
+  fireEvent.keyDown(input, { key: 'Delete' });
+  input.remove();
+
+  expect(utils.props.updateScenes).not.toHaveBeenCalled();
+  expect(utils.props.clearScenes).not.toHaveBeenCalled();
+});
+
+test('Clear all button opens a confirmation dialog and clears on confirm', () => {
+  const utils = renderClaymate();
+
+  fireEvent.click(utils.getByText('Clear all'));
+
+  // Confirm button in the dialog
+  fireEvent.click(utils.getByText('Delete'));
+
+  expect(utils.props.clearScenes).toHaveBeenCalledTimes(1);
+});
+
+test('Clear all is disabled when there is a single empty scene', () => {
+  const utils = renderClaymate({
+    scenes: [makeScene('only')],
+    currentIndex: 0,
+  });
+  expect(utils.getByText('Clear all')).toBeDisabled();
+});
+
+test('Clear all is enabled when the only scene has content', () => {
+  const utils = renderClaymate({
+    scenes: [makeScene('only', [{ id: 'el1' }])],
+    currentIndex: 0,
+  });
+  expect(utils.getByText('Clear all')).toBeEnabled();
+});
+
+test('Delete with currentIndex undefined removes selected scenes without crash', () => {
+  const utils = renderClaymate({ currentIndex: undefined });
+  selectScene(utils, 1);
+
+  fireEvent.keyDown(document.body, { key: 'Delete' });
+
+  expect(utils.props.updateScenes).toHaveBeenCalledTimes(1);
+  const updater = (utils.props.updateScenes as any).mock.calls[0][0];
+  const result = updater(utils.props.scenes).map((s: Scene) => s.id);
+  expect(result).toEqual(['a', 'c']);
+  // newCurrent arg should be undefined — no crash
+  const newCurrent = (utils.props.updateScenes as any).mock.calls[0][1];
+  expect(newCurrent).toBeUndefined();
+});
+
+test('Delete is ignored when focus is in a select element', () => {
+  const utils = renderClaymate();
+  selectScene(utils, 1);
+
+  const select = document.createElement('select');
+  document.body.appendChild(select);
+  fireEvent.keyDown(select, { key: 'Delete' });
+  select.remove();
+
+  expect(utils.props.updateScenes).not.toHaveBeenCalled();
+  expect(utils.props.clearScenes).not.toHaveBeenCalled();
+});

--- a/src/Claymate.test.tsx
+++ b/src/Claymate.test.tsx
@@ -58,11 +58,14 @@ test('clicking a scene checkbox does not navigate to that scene', () => {
   expect(utils.props.moveToScene).not.toHaveBeenCalled();
 });
 
-test('Delete removes only the selected scenes', () => {
+test('Delete opens confirmation dialog and removes selected scenes on confirm', () => {
   const utils = renderClaymate();
   selectScene(utils, 1);
 
   fireEvent.keyDown(document.body, { key: 'Delete' });
+
+  expect(utils.props.updateScenes).not.toHaveBeenCalled();
+  fireEvent.click(utils.getByText('Clear'));
 
   expect(utils.props.updateScenes).toHaveBeenCalledTimes(1);
   expect(utils.props.clearScenes).not.toHaveBeenCalled();
@@ -71,12 +74,15 @@ test('Delete removes only the selected scenes', () => {
   expect(result).toEqual(['a', 'c']);
 });
 
-test('Backspace removes only the selected scenes', () => {
+test('Backspace opens confirmation dialog and removes selected scenes on confirm', () => {
   const utils = renderClaymate();
   selectScene(utils, 0);
   selectScene(utils, 2);
 
   fireEvent.keyDown(document.body, { key: 'Backspace' });
+
+  expect(utils.props.updateScenes).not.toHaveBeenCalled();
+  fireEvent.click(utils.getByText('Clear'));
 
   expect(utils.props.updateScenes).toHaveBeenCalledTimes(1);
   const updater = (utils.props.updateScenes as any).mock.calls[0][0];
@@ -84,13 +90,16 @@ test('Backspace removes only the selected scenes', () => {
   expect(result).toEqual(['b']);
 });
 
-test('selecting all scenes and pressing Delete clears to one empty scene', () => {
+test('selecting all scenes and pressing Delete shows confirmation before clearing', () => {
   const utils = renderClaymate();
   selectScene(utils, 0);
   selectScene(utils, 1);
   selectScene(utils, 2);
 
   fireEvent.keyDown(document.body, { key: 'Delete' });
+
+  expect(utils.props.clearScenes).not.toHaveBeenCalled();
+  fireEvent.click(utils.getByText('Clear'));
 
   expect(utils.props.clearScenes).toHaveBeenCalledTimes(1);
   expect(utils.props.updateScenes).not.toHaveBeenCalled();
@@ -135,7 +144,7 @@ test('Clear all button opens a confirmation dialog and clears on confirm', () =>
   fireEvent.click(utils.getByText('Clear all'));
 
   // Confirm button in the dialog
-  fireEvent.click(utils.getByText('Delete'));
+  fireEvent.click(utils.getByText('Clear'));
 
   expect(utils.props.clearScenes).toHaveBeenCalledTimes(1);
 });
@@ -161,6 +170,7 @@ test('Delete with currentIndex undefined removes selected scenes without crash',
   selectScene(utils, 1);
 
   fireEvent.keyDown(document.body, { key: 'Delete' });
+  fireEvent.click(utils.getByText('Clear'));
 
   expect(utils.props.updateScenes).toHaveBeenCalledTimes(1);
   const updater = (utils.props.updateScenes as any).mock.calls[0][0];

--- a/src/Claymate.tsx
+++ b/src/Claymate.tsx
@@ -60,6 +60,7 @@ type Props = {
   ) => void;
   moveToScene: (index: number) => void;
   addScene: (optionalDrawing?: Drawing) => void;
+  clearScenes: () => void;
   autoAddSceneUnit?: number;
 };
 
@@ -79,12 +80,17 @@ const Claymate = ({
   updateScenes,
   moveToScene,
   addScene,
+  clearScenes,
   autoAddSceneUnit = 0.1,
 }: Props) => {
   const [previewState, setPreviewState] = useState<PreviewState>({
     open: false,
     url: '',
   });
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [showClearConfirm, setShowClearConfirm] = useState(false);
+  const [showDeleteSelectedConfirm, setShowDeleteSelectedConfirm] =
+    useState(false);
   const [showAutoSceneConfig, setShowAutoSceneConfig] = useState(false);
   const [autoSceneConfig, setAutoSceneConfig] = useState<AutoSceneConfig>({
     enabled: false,
@@ -199,6 +205,116 @@ const Claymate = ({
     );
   };
 
+  const toggleSelected = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const isSingleEmptyScene =
+    scenes.length === 0 ||
+    (scenes.length === 1 && isEmpty(scenes[0].drawing.elements));
+
+  const deleteSelected = useCallback(() => {
+    if (selectedIds.size === 0) return;
+
+    if (selectedIds.size === scenes.length) {
+      clearScenes();
+      setSelectedIds(new Set());
+      return;
+    }
+
+    const remaining = scenes.filter((scene) => !selectedIds.has(scene.id));
+
+    let nextSelectedScene: { index: number; drawing: Drawing } | undefined;
+    if (currentIndex !== undefined) {
+      const currentScene = scenes[currentIndex];
+      let targetScene: Scene | undefined;
+      if (currentScene && !selectedIds.has(currentScene.id)) {
+        targetScene = currentScene;
+      } else {
+        // nearest surviving scene before the current one, else the first remaining
+        targetScene = [...scenes.slice(0, currentIndex)]
+          .reverse()
+          .find((scene) => !selectedIds.has(scene.id));
+        targetScene = targetScene ?? remaining[0];
+      }
+      const nextIndex = remaining.findIndex(
+        (scene) => scene.id === targetScene?.id,
+      );
+      nextSelectedScene = {
+        index: nextIndex,
+        drawing: remaining[nextIndex].drawing,
+      };
+    }
+
+    updateScenes(
+      (prev) => prev.filter((scene) => !selectedIds.has(scene.id)),
+      nextSelectedScene,
+    );
+    setSelectedIds(new Set());
+  }, [selectedIds, scenes, currentIndex, clearScenes, updateScenes]);
+
+  // Keep the selection in sync with the scenes that still exist.
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      const existingIds = new Set(scenes.map((scene) => scene.id));
+      let changed = false;
+      const next = new Set<string>();
+      prev.forEach((id) => {
+        if (existingIds.has(id)) {
+          next.add(id);
+        } else {
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
+  }, [scenes]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Delete' && event.key !== 'Backspace') return;
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      // Don't interfere with deleting elements inside the Excalidraw canvas.
+      if (
+        typeof target.closest === 'function' &&
+        target.closest('.excalidraw')
+      ) {
+        return;
+      }
+      // Don't interfere with text entry or select elements.
+      if (
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.isContentEditable
+      )
+        return;
+      if (target.tagName === 'INPUT') {
+        const type = (target as HTMLInputElement).type;
+        if (type !== 'checkbox' && type !== 'radio' && type !== 'button') {
+          return;
+        }
+      }
+      deleteSelected();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [deleteSelected]);
+
+  const confirmClearAll = () => {
+    clearScenes();
+    setSelectedIds(new Set());
+    setShowClearConfirm(false);
+  };
+
   useEffect(() => {
     if (autoSceneConfig.enabled) {
       autoSceneInterval.current = setInterval(
@@ -238,6 +354,14 @@ const Claymate = ({
               data-testid={testId}
             >
               <Preview scene={scene} darkMode={darkMode} />
+              <input
+                type="checkbox"
+                className="Claymate-select"
+                aria-label="Select scene"
+                checked={selectedIds.has(scene.id)}
+                onChange={() => toggleSelected(scene.id)}
+                onClick={(event) => event.stopPropagation()}
+              />
               <button
                 type="button"
                 className="Claymate-delete"
@@ -337,13 +461,30 @@ const Claymate = ({
             Export HTML
           </button>
         </div>
-        <button
-          type="button"
-          onClick={reverseOrder}
-          disabled={scenes.length <= 1}
-        >
-          Reverse order
-        </button>
+        <div>
+          <button
+            type="button"
+            onClick={reverseOrder}
+            disabled={scenes.length <= 1}
+          >
+            Reverse order
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowClearConfirm(true)}
+            disabled={isSingleEmptyScene}
+          >
+            Clear all
+          </button>
+          {selectedIds.size > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowDeleteSelectedConfirm(true)}
+            >
+              Delete selected ({selectedIds.size})
+            </button>
+          )}
+        </div>
       </div>
 
       {/* Preview GIF Dialog */}
@@ -363,20 +504,57 @@ const Claymate = ({
         </Dialog>
       )}
 
-      {/* Preview GIF Dialog */}
-      {previewState.open && (
+      {/* Clear all confirmation Dialog */}
+      {showClearConfirm && (
         <Dialog
-          open={previewState.open}
-          title="Preview GIF"
-          handleClose={closePreview}
+          open={showClearConfirm}
+          title="Clear all scenes?"
+          handleClose={() => setShowClearConfirm(false)}
+          actions={
+            <>
+              <button type="button" onClick={() => setShowClearConfirm(false)}>
+                Cancel
+              </button>
+              <button type="button" onClick={confirmClearAll}>
+                Delete
+              </button>
+            </>
+          }
         >
-          <div className="preview-gif-wrapper">
-            <img
-              src={previewState.url}
-              alt="Preview GIF"
-              className="preview-gif"
-            />
-          </div>
+          <p>This removes every scene and leaves a single empty scene.</p>
+        </Dialog>
+      )}
+
+      {/* Delete selected confirmation Dialog */}
+      {showDeleteSelectedConfirm && (
+        <Dialog
+          open={showDeleteSelectedConfirm}
+          title={`Delete ${selectedIds.size} scene${selectedIds.size > 1 ? 's' : ''}?`}
+          handleClose={() => setShowDeleteSelectedConfirm(false)}
+          actions={
+            <>
+              <button
+                type="button"
+                onClick={() => setShowDeleteSelectedConfirm(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  deleteSelected();
+                  setShowDeleteSelectedConfirm(false);
+                }}
+              >
+                Delete
+              </button>
+            </>
+          }
+        >
+          <p>
+            Delete {selectedIds.size} selected scene
+            {selectedIds.size > 1 ? 's' : ''}?
+          </p>
         </Dialog>
       )}
     </div>

--- a/src/Claymate.tsx
+++ b/src/Claymate.tsx
@@ -135,7 +135,6 @@ const Claymate = ({
     });
   };
 
-
   const moveLeft = (id: string) => {
     const index = scenes.findIndex((item) => item.id === id);
     updateScenes(

--- a/src/Claymate.tsx
+++ b/src/Claymate.tsx
@@ -135,37 +135,6 @@ const Claymate = ({
     });
   };
 
-  const deleteScene = (id: string) => {
-    const deletedSceneIndex = scenes.findIndex((item) => item.id === id);
-    if (deletedSceneIndex < 0) return;
-    let nextSelectedScene = undefined;
-
-    if (currentIndex !== undefined) {
-      const remainingScenesCount = scenes.length - 1;
-      const nextIndex =
-        currentIndex === remainingScenesCount ||
-        currentIndex > deletedSceneIndex
-          ? currentIndex - 1
-          : currentIndex;
-
-      const nextDrawingIndex =
-        deletedSceneIndex <= currentIndex &&
-        remainingScenesCount !== deletedSceneIndex
-          ? nextIndex + 1
-          : nextIndex;
-
-      nextSelectedScene = {
-        index: nextIndex,
-        drawing: scenes[nextDrawingIndex].drawing,
-      };
-    }
-
-    updateScenes((prev) => {
-      const next = [...prev];
-      next.splice(deletedSceneIndex, 1);
-      return next;
-    }, nextSelectedScene);
-  };
 
   const moveLeft = (id: string) => {
     const index = scenes.findIndex((item) => item.id === id);
@@ -303,11 +272,13 @@ const Claymate = ({
           return;
         }
       }
-      deleteSelected();
+      if (selectedIds.size > 0) {
+        setShowDeleteSelectedConfirm(true);
+      }
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [deleteSelected]);
+  }, [selectedIds.size]);
 
   const confirmClearAll = () => {
     clearScenes();
@@ -362,18 +333,6 @@ const Claymate = ({
                 onChange={() => toggleSelected(scene.id)}
                 onClick={(event) => event.stopPropagation()}
               />
-              <button
-                type="button"
-                className="Claymate-delete"
-                aria-label="Delete"
-                disabled={scenes.length <= 1}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  deleteScene(scene.id);
-                }}
-              >
-                &#x2716;
-              </button>
               <button
                 type="button"
                 className="Claymate-left"
@@ -481,7 +440,7 @@ const Claymate = ({
               type="button"
               onClick={() => setShowDeleteSelectedConfirm(true)}
             >
-              Delete selected ({selectedIds.size})
+              Clear selected ({selectedIds.size})
             </button>
           )}
         </div>
@@ -516,7 +475,7 @@ const Claymate = ({
                 Cancel
               </button>
               <button type="button" onClick={confirmClearAll}>
-                Delete
+                Clear
               </button>
             </>
           }
@@ -525,11 +484,11 @@ const Claymate = ({
         </Dialog>
       )}
 
-      {/* Delete selected confirmation Dialog */}
+      {/* Clear selected confirmation Dialog */}
       {showDeleteSelectedConfirm && (
         <Dialog
           open={showDeleteSelectedConfirm}
-          title={`Delete ${selectedIds.size} scene${selectedIds.size > 1 ? 's' : ''}?`}
+          title={`Clear ${selectedIds.size} scene${selectedIds.size > 1 ? 's' : ''}?`}
           handleClose={() => setShowDeleteSelectedConfirm(false)}
           actions={
             <>
@@ -546,13 +505,13 @@ const Claymate = ({
                   setShowDeleteSelectedConfirm(false);
                 }}
               >
-                Delete
+                Clear
               </button>
             </>
           }
         >
           <p>
-            Delete {selectedIds.size} selected scene
+            Clear {selectedIds.size} selected scene
             {selectedIds.size > 1 ? 's' : ''}?
           </p>
         </Dialog>

--- a/src/components/ui/Dialog/Dialog.tsx
+++ b/src/components/ui/Dialog/Dialog.tsx
@@ -27,9 +27,6 @@ export const Dialog = ({
           {headerActions && (
             <div className="header-actions">{headerActions}</div>
           )}
-          <button className="close-button" onClick={handleClose}>
-            X
-          </button>
         </div>
 
         {(dividers || dividerTop) && <div className="divider" />}

--- a/src/components/ui/Dialog/Dialog.tsx
+++ b/src/components/ui/Dialog/Dialog.tsx
@@ -20,8 +20,8 @@ export const Dialog = ({
   if (!open) return null;
   const modalClassname = `claymate-modal ${className} ${position}`;
   return createPortal(
-    <div className="claymate-modal-wrapper">
-      <div className={modalClassname}>
+    <div className="claymate-modal-wrapper" onClick={handleClose}>
+      <div className={modalClassname} onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h2 className="typography">{title}</h2>
           {headerActions && (

--- a/src/components/ui/Dialog/Dialog.tsx
+++ b/src/components/ui/Dialog/Dialog.tsx
@@ -20,8 +20,13 @@ export const Dialog = ({
   if (!open) return null;
   const modalClassname = `claymate-modal ${className} ${position}`;
   return createPortal(
-    <div className="claymate-modal-wrapper" onClick={handleClose}>
-      <div className={modalClassname} onClick={(e) => e.stopPropagation()}>
+    <div
+      className="claymate-modal-wrapper"
+      role="presentation"
+      onClick={(e) => e.target === e.currentTarget && handleClose()}
+      onKeyDown={(e) => e.key === 'Escape' && handleClose()}
+    >
+      <div className={modalClassname} role="dialog" aria-modal="true" aria-label={title}>
         <div className="modal-header">
           <h2 className="typography">{title}</h2>
           {headerActions && (

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -20,6 +20,16 @@ try {
 } catch {
   //ignore
 }
+(global as any).ImageData = class {
+  data: Uint8ClampedArray;
+  width: number;
+  height: number;
+  constructor(width: number, height: number) {
+    this.width = width;
+    this.height = height;
+    this.data = new Uint8ClampedArray(width * height * 4);
+  }
+};
 (window as any).Path2D = function () {
   // empty
 };

--- a/src/useScenes.test.ts
+++ b/src/useScenes.test.ts
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { test, expect } from 'vitest';
+
+import { useScenes } from './useScenes';
+
+const appState: any = {
+  theme: 'light',
+  viewBackgroundColor: '#ffffff',
+  exportBackground: true,
+  exportWithDarkMode: false,
+  exportScale: 1,
+  width: 100,
+  height: 100,
+};
+
+test('clearScenes is a no-op when appState is not yet available', async () => {
+  const { result } = renderHook(() => useScenes());
+  // Do NOT call onChange — so drawing and scenes stay uninitialised.
+  // clearScenes should not throw and scenes should remain empty.
+  act(() => {
+    result.current.clearScenes();
+  });
+  // Still no scenes (init hasn't completed yet either).
+  expect(result.current.scenes.length).toBe(0);
+});
+
+test('clearScenes leaves exactly one empty scene', async () => {
+  const { result } = renderHook(() => useScenes());
+  await waitFor(() => expect(result.current.currentIndex).toBe(0));
+
+  // Seed the first scene via Excalidraw's onChange, then add more.
+  act(() => {
+    result.current.onChange([] as any, appState, {} as any);
+  });
+  await waitFor(() => expect(result.current.scenes.length).toBe(1));
+
+  act(() => {
+    result.current.addScene();
+  });
+  await waitFor(() => expect(result.current.scenes.length).toBe(2));
+  act(() => {
+    result.current.addScene();
+  });
+  await waitFor(() => expect(result.current.scenes.length).toBe(3));
+
+  act(() => {
+    result.current.clearScenes();
+  });
+
+  await waitFor(() => expect(result.current.scenes.length).toBe(1));
+  expect(result.current.scenes[0].drawing.elements).toEqual([]);
+  expect(result.current.currentIndex).toBe(0);
+});

--- a/src/useScenes.ts
+++ b/src/useScenes.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types';
 import type { AppState, BinaryFiles } from '@excalidraw/excalidraw/types';
+import { nanoid } from 'nanoid';
 import { createScene } from './creation';
 import type { Drawing, Scene } from './types';
 import { loadStorage, saveStorage } from './persistence';
@@ -141,6 +142,31 @@ export const useScenes = () => {
     [updateScenes, scenes, drawing],
   );
 
+  const clearScenes = useCallback(() => {
+    const appState =
+      drawing?.appState ??
+      (currentIndex !== undefined
+        ? scenes[currentIndex]?.drawing.appState
+        : scenes[0]?.drawing.appState);
+    if (!appState) {
+      return;
+    }
+    const blankDrawing: Drawing = { elements: [], appState, files: null };
+    (async () => {
+      const scene = await createScene(blankDrawing);
+      // createScene can return undefined if canvas has zero dimensions.
+      // Fall back to a minimal scene so clearScenes never silently no-ops.
+      const finalScene = scene ?? {
+        id: nanoid(),
+        width: 1,
+        height: 1,
+        imageData: new ImageData(1, 1),
+        drawing: blankDrawing,
+      };
+      updateScenes(() => [finalScene], { index: 0, drawing: blankDrawing });
+    })();
+  }, [drawing, currentIndex, scenes, updateScenes]);
+
   useEffect(() => {
     if (initialisedRef.current === Initialisation.NotStarted) {
       initialisedRef.current = Initialisation.Started;
@@ -167,6 +193,7 @@ export const useScenes = () => {
   return {
     moveToScene,
     addScene,
+    clearScenes,
     onChange,
     drawingVersion,
     currentIndex,

--- a/src/useScenes.ts
+++ b/src/useScenes.ts
@@ -15,6 +15,7 @@ enum Initialisation {
 
 export const useScenes = () => {
   const initialisedRef = useRef<Initialisation>(Initialisation.NotStarted);
+  const generationRef = useRef(0);
   const [drawingVersion, setDrawingVersion] = useState(0);
   const [currentIndex, setCurrentIndex] = useState<number | undefined>(0);
   const [scenes, setScenes] = useState<Scene[]>([]);
@@ -50,6 +51,7 @@ export const useScenes = () => {
   const updateCurrentScene = useCallback(
     (index: number, drawing: Drawing) => {
       if (index != null && drawing) {
+        const generation = generationRef.current;
         (async () => {
           const scene = await createScene(
             drawing,
@@ -60,6 +62,7 @@ export const useScenes = () => {
                   height: requiredHeight,
                 },
           );
+          if (generationRef.current !== generation) return;
           if (scene) {
             setScenes((prev) => {
               const result = [...prev];
@@ -122,6 +125,7 @@ export const useScenes = () => {
     (optionalDrawing?: Drawing) => {
       const drawingToAdd = optionalDrawing || drawing;
       if (drawingToAdd) {
+        const generation = generationRef.current;
         (async () => {
           const scene = await createScene(
             drawingToAdd,
@@ -130,6 +134,7 @@ export const useScenes = () => {
               height: scenes[0].height,
             },
           );
+          if (generationRef.current !== generation) return;
           if (scene) {
             updateScenes((prev) => [...prev, scene], {
               index: scenes.length,
@@ -143,6 +148,7 @@ export const useScenes = () => {
   );
 
   const clearScenes = useCallback(() => {
+    generationRef.current += 1;
     const appState =
       drawing?.appState ??
       (currentIndex !== undefined
@@ -163,9 +169,18 @@ export const useScenes = () => {
         imageData: new ImageData(1, 1),
         drawing: blankDrawing,
       };
-      updateScenes(() => [finalScene], { index: 0, drawing: blankDrawing });
+      // Second increment: cancels any updateCurrentScene calls that were
+      // triggered by onChange during the createScene await above. Those
+      // calls captured the post-first-increment generation and would pass
+      // the stale-check, but they carry the old currentIndex and would
+      // append/overwrite scenes after we reset to a single blank scene.  
+      generationRef.current += 1;
+      setScenes(() => [finalScene]);
+      setCurrentIndex(0);
+      setDrawing(blankDrawing);
+      setDrawingVersion((v) => v + 1);
     })();
-  }, [drawing, currentIndex, scenes, updateScenes]);
+  }, [drawing, currentIndex, scenes]);
 
   useEffect(() => {
     if (initialisedRef.current === Initialisation.NotStarted) {

--- a/src/useScenes.ts
+++ b/src/useScenes.ts
@@ -158,28 +158,17 @@ export const useScenes = () => {
       return;
     }
     const blankDrawing: Drawing = { elements: [], appState, files: null };
-    (async () => {
-      const scene = await createScene(blankDrawing);
-      // createScene can return undefined if canvas has zero dimensions.
-      // Fall back to a minimal scene so clearScenes never silently no-ops.
-      const finalScene = scene ?? {
-        id: nanoid(),
-        width: 1,
-        height: 1,
-        imageData: new ImageData(1, 1),
-        drawing: blankDrawing,
-      };
-      // Second increment: cancels any updateCurrentScene calls that were
-      // triggered by onChange during the createScene await above. Those
-      // calls captured the post-first-increment generation and would pass
-      // the stale-check, but they carry the old currentIndex and would
-      // append/overwrite scenes after we reset to a single blank scene.  
-      generationRef.current += 1;
-      setScenes(() => [finalScene]);
-      setCurrentIndex(0);
-      setDrawing(blankDrawing);
-      setDrawingVersion((v) => v + 1);
-    })();
+    const finalScene = {
+      id: nanoid(),
+      width: 1,
+      height: 1,
+      imageData: new ImageData(1, 1),
+      drawing: blankDrawing,
+    };
+    setScenes(() => [finalScene]);
+    setCurrentIndex(0);
+    setDrawing(blankDrawing);
+    setDrawingVersion((v) => v + 1);
   }, [drawing, currentIndex, scenes]);
 
   useEffect(() => {


### PR DESCRIPTION
Add "Clear all" button and multi-select delete for scenes

- New clearScenes() in useScenes: replaces all scenes with one blank scene (preserving theme), with fallback if createScene returns undefined
- Per-scene checkbox for multi-select; Delete/Backspace hotkey deletes selected scenes (or calls clearScenes when all are selected)
- Keydown guard: ignored inside .excalidraw, input, textarea, select, contentEditable
- "Clear all" button (disabled on single empty scene) and "Delete selected (N)" button, both with confirmation dialogs
- Selected scene highlighted with blue tint via :has() CSS
- Fixes duplicate Preview GIF Dialog block
- 15 tests covering all new behaviours